### PR TITLE
One missed "setting", removing a fallback

### DIFF
--- a/WebHostLib/misc.py
+++ b/WebHostLib/misc.py
@@ -49,12 +49,6 @@ def weighted_options():
     return render_template("weighted-options.html")
 
 
-# TODO for back compat. remove around 0.4.5
-@app.route("/games/<string:game>/player-settings")
-def player_settings(game: str):
-    return redirect(url_for("player_options", game=game), 301)
-
-
 # Player options pages
 @app.route("/games/<string:game>/player-options")
 @cache.cached()

--- a/worlds/yoshisisland/docs/setup_en.md
+++ b/worlds/yoshisisland/docs/setup_en.md
@@ -39,7 +39,7 @@ guide: [Basic Multiworld Setup Guide](/tutorial/Archipelago/setup/en)
 
 ### Where do I get a config file?
 
-The Player Options page on the website allows you to configure your personal settings and export a config file from
+The Player Options page on the website allows you to configure your personal options and export a config file from
 them.
 
 ### Verifying your config file


### PR DESCRIPTION
## What is this fixing or adding?

Removes a fallback for "player-settings" since that no longer exists and fixes the only instance of "settings" I could find that should be "options"

## How was this tested?

Reading