### PR TITLE
Docs, SM64: Fix typo and odd capitalization

### DIFF
--- a/worlds/sm64ex/docs/en_Super Mario 64.md
+++ b/worlds/sm64ex/docs/en_Super Mario 64.md
@@ -6,23 +6,23 @@ The player options page for this game contains all the options you need to confi
 options page link: [SM64EX Player Options Page](../player-options).
 
 ## What does randomization do to this game?
-All 120 Stars, the 3 Cap Switches, the Basement and Secound Floor Key are now Location Checks and may contain Items for different games as well
-as different Items from within SM64.
+All 120 Stars, the 3 Cap Switches, the Basement and Second Floor Key are now location checks and may contain items for different games as well
+as different items from within SM64.
 
 
 ## What is the goal of SM64EX when randomized?
-As in most Mario Games, save the Princess!
+As in most Mario games, save the Princess!
 
 ## Which items can be in another player's world?
 Any of the 120 Stars, and the two Castle Keys. Additionally, Cap Switches are also considered "Items" and the "!"-Boxes will only be active
-when someone collects the corresponding Cap Switch Item.
+when someone collects the corresponding Cap Switch item.
 
 ## What does another world's item look like in SM64EX?
-The Items are visually unchanged, though after collecting a Message will pop up to inform you what you collected,
+The items are visually unchanged, though after collecting a message will pop up to inform you what you collected,
 and who will receive it.
 
 ## When the player receives an item, what happens?
-When you receive an Item, a Message will pop up to inform you where you received the Item from,
+When you receive an item, a message will pop up to inform you where you received the item from,
 and which one it is.
 
-NOTE: The Secret Star count in the Menu is broken.
+NOTE: The Secret Star count in the menu is broken.


### PR DESCRIPTION
## What is this fixing or adding?
Fixes typo and odd capitalization in the Super Mario 64 game page documentation.